### PR TITLE
Add dark mode toggle and modern styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A comprehensive, elegant PDF manipulation tool built with React, TypeScript, and
 - **Drag & Drop**: Intuitive file upload interface
 - **Progress Tracking**: Real-time processing feedback
 - **Responsive Design**: Works on desktop, tablet, and mobile
+- **Dark Mode Toggle**: Switch between light and dark themes
 
 ### 🚧 Coming Soon
 - **Edit PDF**: Canvas-based PDF editor with text, images, and annotations
@@ -26,6 +27,7 @@ A comprehensive, elegant PDF manipulation tool built with React, TypeScript, and
 - **Vite** for fast development and building
 - **Bulma CSS** for elegant styling
 - **Phosphor Icons** for consistent iconography
+- **Roboto Font** for modern typography
 - **pdf-lib** for client-side PDF manipulation
 - **react-beautiful-dnd** for drag-and-drop functionality
 - **i18next** for internationalization

--- a/index.html
+++ b/index.html
@@ -4,9 +4,12 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap" rel="stylesheet" />
     <title>AuroraPDF - Premium PDF Toolkit</title>
   </head>
-  <body>
+  <body class="theme-light">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,11 +1,13 @@
 import React from 'react'
 import { Link, useLocation } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { House, Wrench } from 'phosphor-react'
+import { House, Wrench, Sun, Moon } from 'phosphor-react'
+import { useTheme } from '../context/ThemeContext'
 
 const Header: React.FC = () => {
   const { t } = useTranslation()
   const location = useLocation()
+  const { theme, toggleTheme } = useTheme()
 
   return (
     <header className="navbar is-primary" role="navigation" aria-label="main navigation">
@@ -36,6 +38,15 @@ const Header: React.FC = () => {
             </span>
             <span>{t('nav.tools')}</span>
           </Link>
+        </div>
+        <div className="navbar-end">
+          <button
+            className="navbar-item button is-white is-small"
+            onClick={toggleTheme}
+            aria-label="toggle theme"
+          >
+            {theme === 'light' ? <Moon size={20} /> : <Sun size={20} />}
+          </button>
         </div>
       </div>
     </header>

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,0 +1,38 @@
+import React, { createContext, useContext, useEffect, useState } from 'react'
+
+export type Theme = 'light' | 'dark'
+
+interface ThemeContextType {
+  theme: Theme
+  toggleTheme: () => void
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined)
+
+export const useTheme = () => {
+  const ctx = useContext(ThemeContext)
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider')
+  return ctx
+}
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>(() => {
+    return (localStorage.getItem('theme') as Theme) || 'light'
+  })
+
+  useEffect(() => {
+    document.body.classList.remove('theme-light', 'theme-dark')
+    document.body.classList.add(`theme-${theme}`)
+    localStorage.setItem('theme', theme)
+  }, [theme])
+
+  const toggleTheme = () => {
+    setTheme(t => (t === 'light' ? 'dark' : 'light'))
+  }
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import { I18nextProvider } from 'react-i18next'
 import { SWRConfig } from 'swr'
 import App from './App'
 import i18n from './i18n'
+import { ThemeProvider } from './context/ThemeContext'
 import './styles/main.scss'
 
 const fetcher = (url: string) => fetch(url).then(res => res.json())
@@ -13,9 +14,11 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <BrowserRouter>
       <I18nextProvider i18n={i18n}>
-        <SWRConfig value={{ fetcher }}>
-          <App />
-        </SWRConfig>
+        <ThemeProvider>
+          <SWRConfig value={{ fetcher }}>
+            <App />
+          </SWRConfig>
+        </ThemeProvider>
       </I18nextProvider>
     </BrowserRouter>
   </React.StrictMode>,

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1,10 +1,27 @@
 // Bulma theme customization
-$primary: #667eea;
-$link: #764ba2;
-$family-sans-serif: "Inter", "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+$primary: #4285f4;
+$link: #db4437;
+$family-sans-serif: "Roboto", "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
 
 // Import Bulma
 @import "bulma/bulma.sass";
+
+body {
+  font-family: $family-sans-serif;
+}
+
+body.theme-dark {
+  background-color: #121212;
+  color: #e0e0e0;
+
+  .navbar {
+    background-color: #1f1f1f;
+  }
+  .card {
+    background-color: #1e1e1e;
+    color: #e0e0e0;
+  }
+}
 
 // Minimal custom overrides
 .drag-handle {


### PR DESCRIPTION
## Summary
- integrate ThemeContext for light/dark theme
- add a theme switcher button in the header
- update main entry to wrap app with ThemeProvider
- tweak styling with Roboto font and Google-inspired colors
- document new dark mode feature

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_685c51cb1b448329bfb8d05148d272f6